### PR TITLE
Allow the table header to be fixed when the user scrolls the table

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -663,7 +663,7 @@ class MUIDataTable extends React.Component {
   }
 
   render() {
-    const { classes, title } = this.props;
+    const { classes, title, height } = this.props;
     const {
       announceText,
       data,
@@ -679,6 +679,113 @@ class MUIDataTable extends React.Component {
 
     const rowCount = this.options.count || data.length;
     if (!rowCount) return false;
+
+    if (height) {
+      return (
+        <Paper elevation={4} ref={el => (this.tableContent = el)} className={classes.paper}>
+          {selectedRows.data.length && this.options.delete ? (
+            <MUIDataTableToolbarSelect
+              options={this.options}
+              selectedRows={selectedRows}
+              onRowsDelete={this.selectRowDelete}
+            />
+          ) : (
+            <MUIDataTableToolbar
+              columns={columns}
+              data={data}
+              filterData={filterData}
+              filterList={filterList}
+              filterUpdate={this.filterUpdate}
+              options={this.options}
+              resetFilters={this.resetFilters}
+              searchTextUpdate={this.searchTextUpdate}
+              tableRef={() => this.tableContent}
+              title={title}
+              toggleViewColumn={this.toggleViewColumn}
+            />
+          )}
+          <MUIDataTableFilterList options={this.options} filterList={filterList} filterUpdate={this.filterUpdate} />
+          <div className="header-only">
+            <Table ref={el => (this.tableRef = el)} tabIndex={"0"} role={"grid"}>
+              <caption className={classes.caption}>{title}</caption>
+              <MUIDataTableHead
+                columns={columns}
+                data={this.state.displayData}
+                count={rowCount}
+                columns={columns}
+                page={page}
+                rowsPerPage={rowsPerPage}
+                handleHeadUpdateRef={fn => (this.updateToolbarSelect = fn)}
+                selectedRows={selectedRows}
+                selectRowUpdate={this.selectRowUpdate}
+                toggleSort={this.toggleSortColumn}
+                options={this.options}
+              />
+              <MUIDataTableBody
+                data={this.state.displayData}
+                count={rowCount}
+                columns={columns}
+                page={page}
+                rowsPerPage={rowsPerPage}
+                selectedRows={selectedRows}
+                selectRowUpdate={this.selectRowUpdate}
+                options={this.options}
+                searchText={searchText}
+                filterList={filterList}
+              />
+            </Table>
+          </div>
+          <div className="body-only" style={{ overflowY: "auto", height }}>
+            <Table ref={el => (this.tableRef = el)} tabIndex={"0"} role={"grid"}>
+              <caption className={classes.caption}>{title}</caption>
+              <MUIDataTableHead
+                columns={columns}
+                data={this.state.displayData}
+                count={rowCount}
+                columns={columns}
+                page={page}
+                rowsPerPage={rowsPerPage}
+                handleHeadUpdateRef={fn => (this.updateToolbarSelect = fn)}
+                selectedRows={selectedRows}
+                selectRowUpdate={this.selectRowUpdate}
+                toggleSort={this.toggleSortColumn}
+                options={this.options}
+              />
+              <MUIDataTableBody
+                data={this.state.displayData}
+                count={rowCount}
+                columns={columns}
+                page={page}
+                rowsPerPage={rowsPerPage}
+                selectedRows={selectedRows}
+                selectRowUpdate={this.selectRowUpdate}
+                options={this.options}
+                searchText={searchText}
+                filterList={filterList}
+              />
+            </Table>
+          </div>
+          <Table>
+            {this.options.pagination ? (
+              <MUIDataTablePagination
+                count={rowCount}
+                page={page}
+                rowsPerPage={rowsPerPage}
+                changeRowsPerPage={this.changeRowsPerPage}
+                changePage={this.changePage}
+                component={"div"}
+                options={this.options}
+              />
+            ) : (
+              false
+            )}
+          </Table>
+          <div className={classes.liveAnnounce} aria-live={"polite"} ref={el => (this.announceRef = el)}>
+            {announceText}
+          </div>
+        </Paper>
+      );
+    }
 
     return (
       <Paper elevation={4} ref={el => (this.tableContent = el)} className={classes.paper}>


### PR DESCRIPTION
I've made the decision to duplicate the table and keep one just for the header and the other just for the body to avoid misalignment issues like [this one](https://codepen.io/anon/pen/LJPZqj) (this is csstrick's solution, with some changes that break it).